### PR TITLE
feat(olympics): Add endpoint to fetch areas and categories for a specific Olympic

### DIFF
--- a/app/Http/Controllers/AreasController.php
+++ b/app/Http/Controllers/AreasController.php
@@ -10,9 +10,24 @@ use Illuminate\Support\Facades\Validator;
 
 class AreasController extends Controller
 {
+    /**
+     * @OA\Get(
+     *     path="/api/areas",
+     *     summary="List all areas with categories",
+     *     tags={"Areas"},
+     *     @OA\Response(
+     *         response=200,
+     *         description="A list of areas with their associated categories",
+     *         @OA\JsonContent(
+     *             type="array",
+     *             @OA\Items(ref="#/components/schemas/Area")
+     *         )
+     *     )
+     * )
+     */
     public function index()
     {
-        return response()->json(['areas' => Areas::all()]);
+        return response()->json(['areas' => Areas::with('categories')->get()]);
     }
 
     public function store(Request $request)
@@ -51,7 +66,7 @@ class AreasController extends Controller
             ], 409);
         }
 
-    
+
         $area = new Areas;
         $area->name = $request->name;
         $area->description = $request->description;
@@ -62,6 +77,4 @@ class AreasController extends Controller
             'message' => 'Área creada con éxito'
         ], 201);
     }
-
-    
 }

--- a/app/Models/Areas.php
+++ b/app/Models/Areas.php
@@ -5,8 +5,50 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
+/**
+ * @OA\Schema(
+ *     schema="Area",
+ *     type="object",
+ *     title="Area",
+ *     required={"id", "name"},
+ *     properties={
+ *         @OA\Property(property="id", type="integer", format="int64", example=1),
+ *         @OA\Property(property="name", type="string", example="Biology"),
+ *         @OA\Property(
+ *             property="categories",
+ *             type="array",
+ *             description="List of categories associated with the area",
+ *             @OA\Items(ref="#/components/schemas/Categories")
+ *         ),
+ *         @OA\Property(property="created_at", type="string", format="date-time", example="2023-01-01T00:00:00Z"),
+ *         @OA\Property(property="updated_at", type="string", format="date-time", example="2023-01-01T00:00:00Z")
+ *     }
+ * )
+ */
 class Areas extends Model
 {
     use HasFactory;
     public $timestamps = false;
+
+    protected $fillable = ['name'];
+
+    /**
+     * Get the categories associated with this area.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     */
+    public function categories()
+    {
+        return $this->hasMany(Categories::class, 'area_id');
+    }
+
+    /**
+     * Get the olympics associated with this area.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
+     */
+    public function olympics()
+    {
+        return $this->belongsToMany(Olympics::class, 'olimpyc_and_categorias', 'area_id', 'olympic_id');
+    }
 }

--- a/app/Models/Categories.php
+++ b/app/Models/Categories.php
@@ -6,6 +6,20 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use App\Models\Areas;
 
+/**
+ * @OA\Schema(
+ *     schema="Categories",
+ *     title="Categories Model",
+ *     description="This model represents the Categories table in the database.",
+ *     required={"id"},
+ *     @OA\Property(property="id", type="integer", format="int64", description="The unique identifier for the category."),
+ *     @OA\Property(property="name", type="string", description="The name of the category."),
+ *     @OA\Property(property="area_id", type="integer", format="int64", description="The ID of the area to which this category belongs."),
+ *     @OA\Property(property="range_course", type="array", @OA\Items(type="string"), description="An array representing the range of courses available in this category.", example={"1ro Primaria", "2do Primaria", "3ro Primaria", "4to Primaria", "5to Primaria", "6to Primaria", "1ro Secundaria", "2do Secundaria", "3ro Secundaria", "4to Secundaria", "5to Secundaria", "6to Secundaria"}),
+ *     @OA\Property(property="created_at", type="string", format="date-time", description="The timestamp when the category was created."),
+ *     @OA\Property(property="updated_at", type="string", format="date-time", description="The timestamp when the category was last updated.")
+ * )
+ */
 class Categories extends Model
 {
     use HasFactory;

--- a/routes/api.php
+++ b/routes/api.php
@@ -65,6 +65,8 @@ Route::get('/inscriptions/excel/template', [ExcelController::class, 'downloadTem
 Route::get('/olympics', [OlympicsController::class, 'index']);
 Route::post('/olympics', [OlympicsController::class, 'store']);
 Route::put('/olympics/{id}', [OlympicsController::class, 'update']);
+Route::get('/olympics/{id}/areas', [OlympicsController::class, 'showAreas']);
+
 // PB 02
 Route::patch('/olympics/{id}/price', [OlympicsController::class, 'updatePrice']);
 //PB 16

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -9,6 +9,30 @@
         "version": "1.0"
     },
     "paths": {
+        "/api/areas": {
+            "get": {
+                "tags": [
+                    "Areas"
+                ],
+                "summary": "List all areas with categories",
+                "operationId": "d4807a1f6d2fa9fc7056e5a53e0c0f4e",
+                "responses": {
+                    "200": {
+                        "description": "A list of areas with their associated categories",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/Area"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/inscriptions": {
             "get": {
                 "tags": [
@@ -949,6 +973,81 @@
                 }
             }
         },
+        "/olympics/{id}/areas": {
+            "get": {
+                "tags": [
+                    "Olympics"
+                ],
+                "summary": "Get areas for a specific olympic",
+                "description": "Returns the list of areas with their categories based on the olympic ID.",
+                "operationId": "getOlympicsAreas",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Olympic ID",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "course",
+                        "in": "query",
+                        "description": "Filter by course range (e.g., 4to Secundaria, 5to Secundaria)",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/Area"
+                                            }
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Resource Not Found"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "errors": {
+                                            "description": "Detailed error message for bad requests.",
+                                            "properties": {
+                                                "param_name": {
+                                                    "type": "string",
+                                                    "example": "Algo salió mal"
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/responsable/access": {
             "post": {
                 "tags": [
@@ -1057,10 +1156,113 @@
             }
         }
     },
+    "components": {
+        "schemas": {
+            "Area": {
+                "title": "Area",
+                "required": [
+                    "id",
+                    "name"
+                ],
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "format": "int64",
+                        "example": 1
+                    },
+                    "name": {
+                        "type": "string",
+                        "example": "Biology"
+                    },
+                    "categories": {
+                        "description": "List of categories associated with the area",
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Categories"
+                        }
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "example": "2023-01-01T00:00:00Z"
+                    },
+                    "updated_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "example": "2023-01-01T00:00:00Z"
+                    }
+                },
+                "type": "object"
+            },
+            "Categories": {
+                "title": "Categories Model",
+                "description": "This model represents the Categories table in the database.",
+                "required": [
+                    "id"
+                ],
+                "properties": {
+                    "id": {
+                        "description": "The unique identifier for the category.",
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "name": {
+                        "description": "The name of the category.",
+                        "type": "string"
+                    },
+                    "area_id": {
+                        "description": "The ID of the area to which this category belongs.",
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "range_course": {
+                        "description": "An array representing the range of courses available in this category.",
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "example": [
+                            "1ro Primaria",
+                            "2do Primaria",
+                            "3ro Primaria",
+                            "4to Primaria",
+                            "5to Primaria",
+                            "6to Primaria",
+                            "1ro Secundaria",
+                            "2do Secundaria",
+                            "3ro Secundaria",
+                            "4to Secundaria",
+                            "5to Secundaria",
+                            "6to Secundaria"
+                        ]
+                    },
+                    "created_at": {
+                        "description": "The timestamp when the category was created.",
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "updated_at": {
+                        "description": "The timestamp when the category was last updated.",
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                },
+                "type": "object"
+            }
+        }
+    },
     "tags": [
+        {
+            "name": "Areas",
+            "description": "Areas"
+        },
         {
             "name": "Inscriptions",
             "description": "Inscriptions"
+        },
+        {
+            "name": "Olympics",
+            "description": "Olympics"
         },
         {
             "name": "Responsable",


### PR DESCRIPTION

- Implements a new GET endpoint \`/olympics/{id}/areas\` in \`OlympicsController@showAreas\`.
- Retrieves areas associated with the given Olympic ID, along with their related categories.
- Supports optional filtering of categories by \`course\` using a query parameter (e.g., \`?course=4to Secundaria\`).
- Adds \`categories()\` and \`olympics()\` relationships to the \`Areas\` model.
- Includes OpenAPI documentation for the new endpoint and related models (\`Area\`, \`Categories\`).